### PR TITLE
refactor: use set to represent chargable days

### DIFF
--- a/src/datasource/ToolStore.java
+++ b/src/datasource/ToolStore.java
@@ -1,43 +1,75 @@
 package datasource;
 
+import static util.DayChecker.DayType.*;
+
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import model.Tool;
 import model.ToolType;
+import util.DayChecker.DayType;
 
 public class ToolStore {
-    private static ToolStore instance;
-    private final List<Tool> tools;
+  private static ToolStore instance;
+  private final List<Tool> tools;
 
-    private ToolStore() {
-        tools = new ArrayList<>();
+  private ToolStore() {
+    tools = new ArrayList<>();
 
-        initDataSource();
+    initDataSource();
+  }
+
+  public static ToolStore getInstance() {
+    if (instance == null) {
+      instance = new ToolStore();
     }
 
-    public static ToolStore getInstance() {
-        if (instance == null) {
-            instance = new ToolStore();
-        }
+    return instance;
+  }
 
-        return instance;
-    }
+  private void initDataSource() {
+    ToolType ladder =
+        new ToolType(
+            "Ladder",
+            1.99,
+            new HashSet<DayType>() {
+              {
+                add(WEEKDAY);
+                add(WEEKEND);
+              }
+            });
 
-    private void initDataSource() {
-        ToolType ladder = new ToolType("Ladder", 1.99, true, true, false);
-        ToolType chainsaw = new ToolType("Chainsaw", 1.49, true, false, true);
-        ToolType jackhammer = new ToolType("Jackhammer", 2.99, true, false, false);
+    ToolType chainsaw =
+        new ToolType(
+            "Chainsaw",
+            1.49,
+            new HashSet<DayType>() {
+              {
+                add(WEEKDAY);
+                add(HOLIDAY);
+              }
+            });
 
-        tools.add(new Tool("CHNS", chainsaw, "Stihl"));
-        tools.add(new Tool("LADW", ladder, "Werner"));
-        tools.add(new Tool("JAKD", jackhammer, "DeWalt"));
-        tools.add(new Tool("JAKR", jackhammer, "Ridgid"));
-    }
+    ToolType jackhammer =
+        new ToolType(
+            "Jackhammer",
+            2.99,
+            new HashSet<DayType>() {
+              {
+                add(WEEKDAY);
+              }
+            });
 
-    public Tool findTool(String toolCode) {
-        return tools.stream()
-                .filter(tool -> tool.getToolCode().equals(toolCode))
-                .findFirst()
-                .orElse(null);
-    }
+    tools.add(new Tool("CHNS", chainsaw, "Stihl"));
+    tools.add(new Tool("LADW", ladder, "Werner"));
+    tools.add(new Tool("JAKD", jackhammer, "DeWalt"));
+    tools.add(new Tool("JAKR", jackhammer, "Ridgid"));
+  }
+
+  public Tool findTool(String toolCode) {
+    return tools.stream()
+        .filter(tool -> tool.getToolCode().equals(toolCode))
+        .findFirst()
+        .orElse(null);
+  }
 }

--- a/src/model/ToolType.java
+++ b/src/model/ToolType.java
@@ -43,4 +43,8 @@ public class ToolType {
   public void addChargeDay(DayType dayType) {
     chargeDays.add(dayType);
   }
+
+  public void removeChargeDay(DayType dayType) {
+    chargeDays.remove(dayType);
+  }
 }

--- a/src/model/ToolType.java
+++ b/src/model/ToolType.java
@@ -48,7 +48,7 @@ public class ToolType {
     chargeDays.remove(dayType);
   }
 
-  public boolean isChargeDay(DayType dayType) {
+  public boolean isChargeableDay(DayType dayType) {
     return chargeDays.contains(dayType);
   }
 }

--- a/src/model/ToolType.java
+++ b/src/model/ToolType.java
@@ -1,53 +1,46 @@
 package model;
 
+import static util.DayChecker.DayType;
+
+import java.util.HashSet;
+import java.util.Set;
+
 public class ToolType {
-    private final String type;
-    private double dailyCharge;
-    private boolean weekdayCharge;
-    private boolean weekendCharge;
-    private boolean holidayCharge;
+  private final String type;
+  private double dailyCharge;
+  private Set<DayType> chargeDays;
 
-    public ToolType(String type, double dailyCharge, boolean weekdayCharge, boolean weekendCharge, boolean holidayCharge) {
-        this.type = type;
-        this.dailyCharge = dailyCharge;
-        this.weekdayCharge = weekdayCharge;
-        this.weekendCharge = weekendCharge;
-        this.holidayCharge = holidayCharge;
-    }
+  public ToolType(String type, double dailyCharge, Set<DayType> chargeDays) {
+    this.type = type;
+    this.dailyCharge = dailyCharge;
+    this.chargeDays = chargeDays;
+  }
 
-    public String getType() {
-        return type;
-    }
+  public ToolType(String type, double dailyCharge) {
+    this(type, dailyCharge, new HashSet<>());
+  }
 
-    public double getDailyCharge() {
-        return dailyCharge;
-    }
+  public String getType() {
+    return type;
+  }
 
-    public void setDailyCharge(double dailyCharge) {
-        this.dailyCharge = dailyCharge;
-    }
+  public double getDailyCharge() {
+    return dailyCharge;
+  }
 
-    public boolean isWeekdayCharge() {
-        return weekdayCharge;
-    }
+  public void setDailyCharge(double dailyCharge) {
+    this.dailyCharge = dailyCharge;
+  }
 
-    public void setWeekdayCharge(boolean weekdayCharge) {
-        this.weekdayCharge = weekdayCharge;
-    }
+  public Set<DayType> getChargeDays() {
+    return chargeDays;
+  }
 
-    public boolean isWeekendCharge() {
-        return weekendCharge;
-    }
+  public void setChargeDays(Set<DayType> chargeDays) {
+    this.chargeDays = chargeDays;
+  }
 
-    public void setWeekendCharge(boolean weekendCharge) {
-        this.weekendCharge = weekendCharge;
-    }
-
-    public boolean isHolidayCharge() {
-        return holidayCharge;
-    }
-
-    public void setHolidayCharge(boolean holidayCharge) {
-        this.holidayCharge = holidayCharge;
-    }
+  public void addChargeDay(DayType dayType) {
+    chargeDays.add(dayType);
+  }
 }

--- a/src/model/ToolType.java
+++ b/src/model/ToolType.java
@@ -47,4 +47,8 @@ public class ToolType {
   public void removeChargeDay(DayType dayType) {
     chargeDays.remove(dayType);
   }
+
+  public boolean isChargeDay(DayType dayType) {
+    return chargeDays.contains(dayType);
+  }
 }

--- a/src/util/Checkout.java
+++ b/src/util/Checkout.java
@@ -71,7 +71,7 @@ public class Checkout {
       DayType dayType = getDayType(date);
       ToolType toolType = getTool().getToolType();
 
-      if (shouldChargeForDayType(dayType, toolType)) {
+      if (toolType.isChargeDay(dayType)) {
         chargeDays++;
       }
 
@@ -79,19 +79,6 @@ public class Checkout {
     }
 
     return chargeDays;
-  }
-
-  private boolean shouldChargeForDayType(DayType dayType, ToolType toolType) {
-    switch (dayType) {
-      case HOLIDAY:
-        return toolType.isHolidayCharge();
-      case WEEKEND:
-        return toolType.isWeekendCharge();
-      case WEEKDAY:
-        return toolType.isWeekdayCharge();
-      default:
-        return false;
-    }
   }
 
   private double getPreDiscountCharge() {

--- a/src/util/Checkout.java
+++ b/src/util/Checkout.java
@@ -71,7 +71,7 @@ public class Checkout {
       DayType dayType = getDayType(date);
       ToolType toolType = getTool().getToolType();
 
-      if (toolType.isChargeDay(dayType)) {
+      if (toolType.isChargeableDay(dayType)) {
         chargeDays++;
       }
 

--- a/test/datasource/ToolStoreTest.java
+++ b/test/datasource/ToolStoreTest.java
@@ -3,8 +3,10 @@ package datasource;
 import static org.junit.jupiter.api.Assertions.*;
 
 import model.Tool;
+import model.ToolType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import util.DayChecker.DayType;
 
 public class ToolStoreTest {
     ToolStore toolStore;
@@ -17,13 +19,15 @@ public class ToolStoreTest {
     @Test
     public void Should_ReturnCorrectTool_When_ToolCodeIsValid() {
         Tool actualTool = toolStore.findTool("CHNS");
+        ToolType actualToolType = actualTool.getToolType();
+
         assertAll(
                 () -> assertEquals("CHNS", actualTool.getToolCode()),
-                () -> assertEquals("Chainsaw", actualTool.getToolType().getType()),
-                () -> assertEquals(1.49, actualTool.getToolType().getDailyCharge()),
-                () -> assertTrue(actualTool.getToolType().isWeekdayCharge()),
-                () -> assertFalse(actualTool.getToolType().isWeekendCharge()),
-                () -> assertTrue(actualTool.getToolType().isHolidayCharge()),
+                () -> assertEquals("Chainsaw", actualToolType.getType()),
+                () -> assertEquals(1.49, actualToolType.getDailyCharge()),
+                () -> assertTrue(actualToolType.isChargeDay(DayType.WEEKDAY)),
+                () -> assertFalse(actualToolType.isChargeDay(DayType.WEEKEND)),
+                () -> assertTrue(actualToolType.isChargeDay(DayType.HOLIDAY)),
                 () -> assertEquals("Stihl", actualTool.getBrand())
         );
     }

--- a/test/datasource/ToolStoreTest.java
+++ b/test/datasource/ToolStoreTest.java
@@ -25,9 +25,9 @@ public class ToolStoreTest {
                 () -> assertEquals("CHNS", actualTool.getToolCode()),
                 () -> assertEquals("Chainsaw", actualToolType.getType()),
                 () -> assertEquals(1.49, actualToolType.getDailyCharge()),
-                () -> assertTrue(actualToolType.isChargeDay(DayType.WEEKDAY)),
-                () -> assertFalse(actualToolType.isChargeDay(DayType.WEEKEND)),
-                () -> assertTrue(actualToolType.isChargeDay(DayType.HOLIDAY)),
+                () -> assertTrue(actualToolType.isChargeableDay(DayType.WEEKDAY)),
+                () -> assertFalse(actualToolType.isChargeableDay(DayType.WEEKEND)),
+                () -> assertTrue(actualToolType.isChargeableDay(DayType.HOLIDAY)),
                 () -> assertEquals("Stihl", actualTool.getBrand())
         );
     }

--- a/test/model/ToolTypeTest.java
+++ b/test/model/ToolTypeTest.java
@@ -1,0 +1,17 @@
+package model;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+import util.DayChecker.DayType;
+
+class ToolTypeTest {
+
+  @Test
+  public void Should_AddChargeDay() {
+    ToolType toolType = new ToolType("Ladder", 1.99);
+    toolType.addChargeDay(DayType.WEEKDAY);
+    assertTrue(toolType.getChargeDays().contains(DayType.WEEKDAY));
+
+  }
+}

--- a/test/model/ToolTypeTest.java
+++ b/test/model/ToolTypeTest.java
@@ -12,7 +12,6 @@ class ToolTypeTest {
     ToolType toolType = new ToolType("Ladder", 1.99);
     toolType.addChargeDay(DayType.WEEKDAY);
     assertTrue(toolType.getChargeDays().contains(DayType.WEEKDAY));
-
   }
 
   @Test
@@ -21,5 +20,18 @@ class ToolTypeTest {
     toolType.addChargeDay(DayType.WEEKDAY);
     toolType.removeChargeDay(DayType.WEEKDAY);
     assertFalse(toolType.getChargeDays().contains(DayType.WEEKDAY));
+  }
+
+  @Test
+  public void Should_ReturnTrue_When_DayTypeIsChargeDay() {
+    ToolType toolType = new ToolType("Ladder", 1.99);
+    toolType.addChargeDay(DayType.WEEKDAY);
+    assertTrue(toolType.isChargeDay(DayType.WEEKDAY));
+  }
+
+  @Test
+  public void Should_ReturnFalse_When_DayTypeIsNotChargeDay() {
+    ToolType toolType = new ToolType("Ladder", 1.99);
+    assertFalse(toolType.isChargeDay(DayType.WEEKDAY));
   }
 }

--- a/test/model/ToolTypeTest.java
+++ b/test/model/ToolTypeTest.java
@@ -14,4 +14,12 @@ class ToolTypeTest {
     assertTrue(toolType.getChargeDays().contains(DayType.WEEKDAY));
 
   }
+
+  @Test
+  public void Should_RemoveChargeDay() {
+    ToolType toolType = new ToolType("Ladder", 1.99);
+    toolType.addChargeDay(DayType.WEEKDAY);
+    toolType.removeChargeDay(DayType.WEEKDAY);
+    assertFalse(toolType.getChargeDays().contains(DayType.WEEKDAY));
+  }
 }

--- a/test/model/ToolTypeTest.java
+++ b/test/model/ToolTypeTest.java
@@ -26,12 +26,12 @@ class ToolTypeTest {
   public void Should_ReturnTrue_When_DayTypeIsChargeDay() {
     ToolType toolType = new ToolType("Ladder", 1.99);
     toolType.addChargeDay(DayType.WEEKDAY);
-    assertTrue(toolType.isChargeDay(DayType.WEEKDAY));
+    assertTrue(toolType.isChargeableDay(DayType.WEEKDAY));
   }
 
   @Test
   public void Should_ReturnFalse_When_DayTypeIsNotChargeDay() {
     ToolType toolType = new ToolType("Ladder", 1.99);
-    assertFalse(toolType.isChargeDay(DayType.WEEKDAY));
+    assertFalse(toolType.isChargeableDay(DayType.WEEKDAY));
   }
 }

--- a/test/util/CheckoutTest.java
+++ b/test/util/CheckoutTest.java
@@ -5,23 +5,22 @@ import static org.junit.jupiter.api.Assertions.*;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.time.LocalDate;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 
 class CheckoutTest {
 
   private static final PrintStream systemOut = System.out;
-  private static final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-  private static final PrintStream testOut = new PrintStream(outputStream);
+  private static ByteArrayOutputStream outputStream;
 
-  @BeforeAll
-  public static void setUp() {
+  @BeforeEach
+  public void setUp() {
+    outputStream = new ByteArrayOutputStream();
+    PrintStream testOut = new PrintStream(outputStream);
     System.setOut(testOut);
   }
 
-  @AfterAll
-  public static void tearDown() {
+  @AfterEach
+  public void tearDown() {
     System.setOut(systemOut);
   }
 
@@ -177,41 +176,41 @@ class CheckoutTest {
     assertTrue(consoleOutput.contains(expectedOutput));
   }
 
-    @Test
-    public void RentalAgreement_Should_ContainPreDiscountCharge_OnCheckout() {
-        Checkout checkout = new Checkout("LADW", 5, 0, LocalDate.of(2023, 6, 30));
-        checkout.generateRentalAgreement();
+  @Test
+  public void RentalAgreement_Should_ContainPreDiscountCharge_OnCheckout() {
+    Checkout checkout = new Checkout("LADW", 5, 0, LocalDate.of(2023, 6, 30));
+    checkout.generateRentalAgreement();
 
-        String consoleOutput = outputStream.toString();
-        String expectedOutput = "Pre-discount charge: $7.96";
+    String consoleOutput = outputStream.toString();
+    String expectedOutput = "Pre-discount charge: $7.96";
 
-        assertTrue(consoleOutput.contains(expectedOutput));
-    }
+    assertTrue(consoleOutput.contains(expectedOutput));
+  }
 
-    @Test
-    public void RentalAgreement_Should_ContainDiscountPercentage_OnCheckout() {
-        Checkout checkout = new Checkout("LADW", 5, 10, LocalDate.of(2023, 6, 30));
-        checkout.generateRentalAgreement();
+  @Test
+  public void RentalAgreement_Should_ContainDiscountPercentage_OnCheckout() {
+    Checkout checkout = new Checkout("LADW", 5, 10, LocalDate.of(2023, 6, 30));
+    checkout.generateRentalAgreement();
 
-        String consoleOutput = outputStream.toString();
-        String expectedOutput = "Discount percent: 10%";
+    String consoleOutput = outputStream.toString();
+    String expectedOutput = "Discount percent: 10%";
 
-        assertTrue(consoleOutput.contains(expectedOutput));
-    }
+    assertTrue(consoleOutput.contains(expectedOutput));
+  }
 
-    @Test
-    public void RentalAgreement_Should_ContainDiscountAmount_OnCheckout() {
-        Checkout checkout = new Checkout("LADW", 5, 10, LocalDate.of(2023, 6, 30));
-        checkout.generateRentalAgreement();
+  @Test
+  public void RentalAgreement_Should_ContainDiscountAmount_OnCheckout() {
+    Checkout checkout = new Checkout("LADW", 5, 10, LocalDate.of(2023, 6, 30));
+    checkout.generateRentalAgreement();
 
-        String consoleOutput = outputStream.toString();
-        String expectedOutput = "Discount amount: $0.80";
+    String consoleOutput = outputStream.toString();
+    String expectedOutput = "Discount amount: $0.80";
 
-        assertTrue(consoleOutput.contains(expectedOutput));
-    }
+    assertTrue(consoleOutput.contains(expectedOutput));
+  }
 
-    @Test
-    public void RentalAgreement_Should_ContainFinalCharge_OnCheckout() {
+  @Test
+  public void RentalAgreement_Should_ContainFinalCharge_OnCheckout() {
     Checkout checkout = new Checkout("LADW", 5, 10, LocalDate.of(2023, 6, 30));
     checkout.generateRentalAgreement();
 
@@ -236,18 +235,19 @@ class CheckoutTest {
     checkout.generateRentalAgreement();
 
     String consoleOutput = outputStream.toString();
-    String expectedOutput = "Tool code: LADW\n" +
-            "Tool type: Ladder\n" +
-            "Tool brand: Werner\n" +
-            "Rental days: 3\n" +
-            "Check out date: 07/02/20\n" +
-            "Due date: 07/05/20\n" +
-            "Daily rental charge: $1.99\n" +
-            "Charge days: 2\n" +
-            "Pre-discount charge: $3.98\n" +
-            "Discount percent: 10%\n" +
-            "Discount amount: $0.40\n" +
-            "Final charge: $3.58\n";
+    String expectedOutput =
+        "Tool code: LADW\n"
+            + "Tool type: Ladder\n"
+            + "Tool brand: Werner\n"
+            + "Rental days: 3\n"
+            + "Check out date: 07/02/20\n"
+            + "Due date: 07/05/20\n"
+            + "Daily rental charge: $1.99\n"
+            + "Charge days: 2\n"
+            + "Pre-discount charge: $3.98\n"
+            + "Discount percent: 10%\n"
+            + "Discount amount: $0.40\n"
+            + "Final charge: $3.58\n";
 
     assertEquals(expectedOutput, consoleOutput);
   }
@@ -258,18 +258,19 @@ class CheckoutTest {
     checkout.generateRentalAgreement();
 
     String consoleOutput = outputStream.toString();
-    String expectedOutput = "Tool code: CHNS\n" +
-            "Tool type: Chainsaw\n" +
-            "Tool brand: Stihl\n" +
-            "Rental days: 5\n" +
-            "Check out date: 07/02/15\n" +
-            "Due date: 07/07/15\n" +
-            "Daily rental charge: $1.49\n" +
-            "Charge days: 3\n" +
-            "Pre-discount charge: $4.47\n" +
-            "Discount percent: 25%\n" +
-            "Discount amount: $1.12\n" +
-            "Final charge: $3.35\n";
+    String expectedOutput =
+        "Tool code: CHNS\n"
+            + "Tool type: Chainsaw\n"
+            + "Tool brand: Stihl\n"
+            + "Rental days: 5\n"
+            + "Check out date: 07/02/15\n"
+            + "Due date: 07/07/15\n"
+            + "Daily rental charge: $1.49\n"
+            + "Charge days: 3\n"
+            + "Pre-discount charge: $4.47\n"
+            + "Discount percent: 25%\n"
+            + "Discount amount: $1.12\n"
+            + "Final charge: $3.35\n";
 
     assertEquals(expectedOutput, consoleOutput);
   }
@@ -280,18 +281,19 @@ class CheckoutTest {
     checkout.generateRentalAgreement();
 
     String consoleOutput = outputStream.toString();
-    String expectedOutput = "Tool code: JAKD\n" +
-            "Tool type: Jackhammer\n" +
-            "Tool brand: DeWalt\n" +
-            "Rental days: 6\n" +
-            "Check out date: 09/03/15\n" +
-            "Due date: 09/09/15\n" +
-            "Daily rental charge: $2.99\n" +
-            "Charge days: 3\n" +
-            "Pre-discount charge: $8.97\n" +
-            "Discount percent: 0%\n" +
-            "Discount amount: $0.00\n" +
-            "Final charge: $8.97\n";
+    String expectedOutput =
+        "Tool code: JAKD\n"
+            + "Tool type: Jackhammer\n"
+            + "Tool brand: DeWalt\n"
+            + "Rental days: 6\n"
+            + "Check out date: 09/03/15\n"
+            + "Due date: 09/09/15\n"
+            + "Daily rental charge: $2.99\n"
+            + "Charge days: 3\n"
+            + "Pre-discount charge: $8.97\n"
+            + "Discount percent: 0%\n"
+            + "Discount amount: $0.00\n"
+            + "Final charge: $8.97\n";
 
     assertEquals(expectedOutput, consoleOutput);
   }
@@ -302,18 +304,19 @@ class CheckoutTest {
     checkout.generateRentalAgreement();
 
     String consoleOutput = outputStream.toString();
-    String expectedOutput = "Tool code: JAKR\n" +
-            "Tool type: Jackhammer\n" +
-            "Tool brand: Ridgid\n" +
-            "Rental days: 9\n" +
-            "Check out date: 07/02/15\n" +
-            "Due date: 07/11/15\n" +
-            "Daily rental charge: $2.99\n" +
-            "Charge days: 5\n" +
-            "Pre-discount charge: $14.95\n" +
-            "Discount percent: 0%\n" +
-            "Discount amount: $0.00\n" +
-            "Final charge: $14.95\n";
+    String expectedOutput =
+        "Tool code: JAKR\n"
+            + "Tool type: Jackhammer\n"
+            + "Tool brand: Ridgid\n"
+            + "Rental days: 9\n"
+            + "Check out date: 07/02/15\n"
+            + "Due date: 07/11/15\n"
+            + "Daily rental charge: $2.99\n"
+            + "Charge days: 5\n"
+            + "Pre-discount charge: $14.95\n"
+            + "Discount percent: 0%\n"
+            + "Discount amount: $0.00\n"
+            + "Final charge: $14.95\n";
 
     assertEquals(expectedOutput, consoleOutput);
   }
@@ -324,18 +327,19 @@ class CheckoutTest {
     checkout.generateRentalAgreement();
 
     String consoleOutput = outputStream.toString();
-    String expectedOutput = "Tool code: JAKR\n" +
-            "Tool type: Jackhammer\n" +
-            "Tool brand: Ridgid\n" +
-            "Rental days: 4\n" +
-            "Check out date: 07/02/20\n" +
-            "Due date: 07/06/20\n" +
-            "Daily rental charge: $2.99\n" +
-            "Charge days: 1\n" +
-            "Pre-discount charge: $2.99\n" +
-            "Discount percent: 50%\n" +
-            "Discount amount: $1.50\n" +
-            "Final charge: $1.50\n";
+    String expectedOutput =
+        "Tool code: JAKR\n"
+            + "Tool type: Jackhammer\n"
+            + "Tool brand: Ridgid\n"
+            + "Rental days: 4\n"
+            + "Check out date: 07/02/20\n"
+            + "Due date: 07/06/20\n"
+            + "Daily rental charge: $2.99\n"
+            + "Charge days: 1\n"
+            + "Pre-discount charge: $2.99\n"
+            + "Discount percent: 50%\n"
+            + "Discount amount: $1.50\n"
+            + "Final charge: $1.50\n";
 
     assertEquals(expectedOutput, consoleOutput);
   }


### PR DESCRIPTION
Before this change, on the ToolType model, I had a property for every type of day, i.e., weekday, weekend, and holiday. It then occurred to me that if we needed a new special day type that was not one of the three, the ToolType model would need a new property and getter/setter.

This change replaces those properties with a Set of DayType to the ToolType model, thus removing the need to call three different methods. One can now call isChargeableDay(DayType) to check if the DayType is on the model. This simplifies the code and makes it extendable in the future.